### PR TITLE
File or image maxsize should be nullable

### DIFF
--- a/features/generate/domain/file.feature
+++ b/features/generate/domain/file.feature
@@ -17,3 +17,21 @@ Feature: It is possible to generate an file class and its dbal type
     Then the command has finished successfully
     And the file "src/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileDBALType.php" should be dumped and look like "../generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileDBALType.php"
     And the file "src/Backend/Modules/TestModule/Domain/MyTestEntity/MyFile.php" should be dumped and look like "../generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyFile.php"
+
+  Scenario: Generate a standalone file code without a max size assert
+    When I run the command "generate:domain:file" and I provide as input
+      """
+      MyFileWithoutMaxSizeAssert[enter]Standalone[enter][enter][enter]
+      """
+    Then the command has finished successfully
+    And the file "src/Standalone/MyFileWithoutMaxSizeAssertDBALType.php" should be dumped and look like "../generate/domain/resources/php71/Standalone/MyFileWithoutMaxSizeAssertDBALType.php"
+    And the file "src/Standalone/MyFileWithoutMaxSizeAssert.php" should be dumped and look like "../generate/domain/resources/php71/Standalone/MyFileWithoutMaxSizeAssert.php"
+
+  Scenario: Generate a module file code without a max size assert
+    When I run the command "generate:domain:file" and I provide as input
+      """
+      MyFileWithoutMaxSizeAssert[enter]Backend\Modules\TestModule\Domain\MyTestEntity[enter][enter][enter]
+      """
+    Then the command has finished successfully
+    And the file "src/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileWithoutMaxSizeAssertDBALType.php" should be dumped and look like "../generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileWithoutMaxSizeAssertDBALType.php"
+    And the file "src/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileWithoutMaxSizeAssert.php" should be dumped and look like "../generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileWithoutMaxSizeAssert.php"

--- a/features/generate/domain/image.feature
+++ b/features/generate/domain/image.feature
@@ -17,3 +17,21 @@ Feature: It is possible to generate an image class and its dbal type
     Then the command has finished successfully
     And the file "src/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageDBALType.php" should be dumped and look like "../generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageDBALType.php"
     And the file "src/Backend/Modules/TestModule/Domain/MyTestEntity/MyImage.php" should be dumped and look like "../generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyImage.php"
+
+  Scenario: Generate a standalone image without a maxsize
+    When I run the command "generate:domain:image" and I provide as input
+      """
+      MyImageWithoutMaxSizeAssert[enter]Standalone[enter][enter]{"image/jpeg"}[enter]err.JPGOnly[enter][enter]
+      """
+    Then the command has finished successfully
+    And the file "src/Standalone/MyImageWithoutMaxSizeAssertDBALType.php" should be dumped and look like "../generate/domain/resources/php71/Standalone/MyImageWithoutMaxSizeAssertDBALType.php"
+    And the file "src/Standalone/MyImageWithoutMaxSizeAssert.php" should be dumped and look like "../generate/domain/resources/php71/Standalone/MyImageWithoutMaxSizeAssert.php"
+
+  Scenario: Generate a module image without a max size assert
+    When I run the command "generate:domain:image" and I provide as input
+      """
+      MyImageWithoutMaxSizeAssert[enter]Backend\Modules\TestModule\Domain\MyTestEntity[enter][enter]{"image/jpeg"}[enter]err.JPGOnly[enter][enter]
+      """
+    Then the command has finished successfully
+    And the file "src/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageWithoutMaxSizeAssertDBALType.php" should be dumped and look like "../generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageWithoutMaxSizeAssertDBALType.php"
+    And the file "src/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageWithoutMaxSizeAssert.php" should be dumped and look like "../generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageWithoutMaxSizeAssert.php"

--- a/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileWithoutMaxSizeAssert.php
+++ b/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileWithoutMaxSizeAssert.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Backend\Modules\TestModule\Domain\MyTestEntity;
+
+use Common\Doctrine\ValueObject\AbstractFile;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class MyFileWithoutMaxSizeAssert extends AbstractFile
+{
+    /**
+     * @var UploadedFile
+     *
+     * @Assert\File()
+     */
+    protected $file;
+
+    protected function getUploadDir(): string
+    {
+        return 'TestModule/MyTestEntity/MyFileWithoutMaxSizeAssert';
+    }
+}

--- a/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileWithoutMaxSizeAssertDBALType.php
+++ b/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyFileWithoutMaxSizeAssertDBALType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Backend\Modules\TestModule\Domain\MyTestEntity;
+
+use Common\Doctrine\Type\AbstractFileType;
+use Common\Doctrine\ValueObject\AbstractFile;
+
+class MyFileWithoutMaxSizeAssertDBALType extends AbstractFileType
+{
+    protected function createFromString(string $fileName): AbstractFile
+    {
+        return MyFileWithoutMaxSizeAssert::fromString($fileName);
+    }
+
+    public function getName(): string
+    {
+        return 'testmodule_mytestentity_myfilewithoutmaxsizeassert';
+    }
+}

--- a/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageWithoutMaxSizeAssert.php
+++ b/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageWithoutMaxSizeAssert.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Backend\Modules\TestModule\Domain\MyTestEntity;
+
+use Common\Doctrine\ValueObject\AbstractImage;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class MyImageWithoutMaxSizeAssert extends AbstractImage
+{
+    /**
+     * @var UploadedFile
+     *
+     * @Assert\File(
+     *     mimeTypes = {"image/jpeg"},
+     *     mimeTypesMessage = "err.JPGOnly"
+     * )
+     */
+    protected $file;
+
+    protected function getUploadDir(): string
+    {
+        return 'TestModule/MyTestEntity/MyImageWithoutMaxSizeAssert';
+    }
+}

--- a/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageWithoutMaxSizeAssertDBALType.php
+++ b/features/generate/domain/resources/php71/Backend/Modules/TestModule/Domain/MyTestEntity/MyImageWithoutMaxSizeAssertDBALType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Backend\Modules\TestModule\Domain\MyTestEntity;
+
+use Common\Doctrine\Type\AbstractImageType;
+use Common\Doctrine\ValueObject\AbstractImage;
+
+class MyImageWithoutMaxSizeAssertDBALType extends AbstractImageType
+{
+    protected function createFromString(string $fileName): AbstractImage
+    {
+        return MyImageWithoutMaxSizeAssert::fromString($fileName);
+    }
+
+    public function getName(): string
+    {
+        return 'testmodule_mytestentity_myimagewithoutmaxsizeassert';
+    }
+}

--- a/features/generate/domain/resources/php71/Standalone/MyFileWithoutMaxSizeAssert.php
+++ b/features/generate/domain/resources/php71/Standalone/MyFileWithoutMaxSizeAssert.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Standalone;
+
+use Common\Doctrine\ValueObject\AbstractFile;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class MyFileWithoutMaxSizeAssert extends AbstractFile
+{
+    /**
+     * @var UploadedFile
+     *
+     * @Assert\File()
+     */
+    protected $file;
+
+    protected function getUploadDir(): string
+    {
+        return 'MyFileWithoutMaxSizeAssert';
+    }
+}

--- a/features/generate/domain/resources/php71/Standalone/MyFileWithoutMaxSizeAssertDBALType.php
+++ b/features/generate/domain/resources/php71/Standalone/MyFileWithoutMaxSizeAssertDBALType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Standalone;
+
+use Common\Doctrine\Type\AbstractFileType;
+use Common\Doctrine\ValueObject\AbstractFile;
+
+class MyFileWithoutMaxSizeAssertDBALType extends AbstractFileType
+{
+    protected function createFromString(string $fileName): AbstractFile
+    {
+        return MyFileWithoutMaxSizeAssert::fromString($fileName);
+    }
+
+    public function getName(): string
+    {
+        return 'myfilewithoutmaxsizeassert';
+    }
+}

--- a/features/generate/domain/resources/php71/Standalone/MyImageWithoutMaxSizeAssert.php
+++ b/features/generate/domain/resources/php71/Standalone/MyImageWithoutMaxSizeAssert.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Standalone;
+
+use Common\Doctrine\ValueObject\AbstractImage;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class MyImageWithoutMaxSizeAssert extends AbstractImage
+{
+    /**
+     * @var UploadedFile
+     *
+     * @Assert\File(
+     *     mimeTypes = {"image/jpeg"},
+     *     mimeTypesMessage = "err.JPGOnly"
+     * )
+     */
+    protected $file;
+
+    protected function getUploadDir(): string
+    {
+        return 'MyImageWithoutMaxSizeAssert';
+    }
+}

--- a/features/generate/domain/resources/php71/Standalone/MyImageWithoutMaxSizeAssertDBALType.php
+++ b/features/generate/domain/resources/php71/Standalone/MyImageWithoutMaxSizeAssertDBALType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Standalone;
+
+use Common\Doctrine\Type\AbstractImageType;
+use Common\Doctrine\ValueObject\AbstractImage;
+
+class MyImageWithoutMaxSizeAssertDBALType extends AbstractImageType
+{
+    protected function createFromString(string $fileName): AbstractImage
+    {
+        return MyImageWithoutMaxSizeAssert::fromString($fileName);
+    }
+
+    public function getName(): string
+    {
+        return 'myimagewithoutmaxsizeassert';
+    }
+}

--- a/src/Domain/File/File.php
+++ b/src/Domain/File/File.php
@@ -18,7 +18,7 @@ class File extends GeneratableClass
 
     public function __construct(
         ClassName $className,
-        string $maxFileSize,
+        ?string $maxFileSize,
         string $uploadDirectory
     ) {
         $this->className = $className;
@@ -54,7 +54,7 @@ class File extends GeneratableClass
         return $this->className;
     }
 
-    public function getMaxFileSize(): string
+    public function getMaxFileSize(): ?string
     {
         return $this->maxFileSize;
     }

--- a/src/Domain/File/File.php71.php.twig
+++ b/src/Domain/File/File.php71.php.twig
@@ -11,7 +11,7 @@ class {{ class.className.name }} extends AbstractFile
     /**
      * @var UploadedFile
      *
-     * @Assert\File(maxSize = "{{ class.maxFileSize }}")
+     * @Assert\File({% if class.maxFileSize %}maxSize = "{{ class.maxFileSize }}"{% endif %})
      */
     protected $file;
 

--- a/src/Domain/File/FileType.php
+++ b/src/Domain/File/FileType.php
@@ -20,8 +20,8 @@ final class FileType extends AbstractType
                 'maxFileSize',
                 TextType::class,
                 [
-                    'label' => 'Max file size',
-                    'data' => $options['max_file_size'],
+                    'label' => 'Max file size (optional)',
+                    'required' => false,
                 ]
             );
     }
@@ -31,7 +31,6 @@ final class FileType extends AbstractType
         $resolver->setDefaults(
             [
                 'data_class' => FileDataTransferObject::class,
-                'max_file_size' => '2M',
             ]
         );
     }

--- a/src/Domain/Image/Image.php
+++ b/src/Domain/Image/Image.php
@@ -24,7 +24,7 @@ final class Image extends GeneratableClass
 
     public function __construct(
         ClassName $className,
-        string $maxFileSize,
+        ?string $maxFileSize,
         string $mimeTypes,
         string $mimeTypeErrorMessage,
         string $uploadDirectory
@@ -66,7 +66,7 @@ final class Image extends GeneratableClass
         return $this->className;
     }
 
-    public function getMaxFileSize(): string
+    public function getMaxFileSize(): ?string
     {
         return $this->maxFileSize;
     }

--- a/src/Domain/Image/Image.php71.php.twig
+++ b/src/Domain/Image/Image.php71.php.twig
@@ -12,7 +12,8 @@ class {{ class.className.name }} extends AbstractImage
      * @var UploadedFile
      *
      * @Assert\File(
-     *     maxSize = "{{ class.maxFileSize }}",
+{% if class.maxFileSize %}     *     maxSize = "{{ class.maxFileSize }}",
+{% endif %}
      *     mimeTypes = {{ class.mimeTypes|raw }},
      *     mimeTypesMessage = "{{ class.mimeTypeErrorMessage }}"
      * )

--- a/src/Domain/Image/ImageType.php
+++ b/src/Domain/Image/ImageType.php
@@ -20,8 +20,8 @@ final class ImageType extends AbstractType
                 'maxFileSize',
                 TextType::class,
                 [
-                    'label' => 'Max file size',
-                    'data' => $options['max_file_size'],
+                    'label' => 'Max file size (optional)',
+                    'required' => false,
                 ]
             )->add(
                 'mimeTypes',
@@ -45,7 +45,6 @@ final class ImageType extends AbstractType
         $resolver->setDefaults(
             [
                 'data_class' => ImageDataTransferObject::class,
-                'max_file_size' => '2M',
                 'mime_types' => '{"image/jpeg", "image/gif", "image/png"}',
                 'mime_type_error_message' => 'err.JPGGIFAndPNGOnly',
             ]


### PR DESCRIPTION
Problem:
When a maxsize is not set a default is chosen. This default value is generated as an assert and is not changed according to the server settings.

Solution:
By removing the default value and allowing to generate values without asserts we can provide other solutions and other logic in ForkCMS